### PR TITLE
fix: common labels merge with stack labels

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,3 +13,4 @@ packages:
   - name: terraform-docs/terraform-docs@v0.18.0
   - name: hashicorp/terraform@v1.9.3
   - name: opentofu/opentofu@v1.8.0
+  - name: spacelift-io/spacectl@v1.8.0

--- a/examples/complete/components/spacelift-automation/stacks/common.yaml
+++ b/examples/complete/components/spacelift-automation/stacks/common.yaml
@@ -1,3 +1,5 @@
 stack_settings:
   administrative: true
   aws_integration_enabled: true
+  labels:
+    - common_label

--- a/examples/complete/components/spacelift-automation/stacks/example.yaml
+++ b/examples/complete/components/spacelift-automation/stacks/example.yaml
@@ -1,2 +1,4 @@
 stack_settings:
   description: This Automation stack is used for Masterpoint's testing purposes
+  labels:
+    - stack_specific_label

--- a/main.tf
+++ b/main.tf
@@ -226,6 +226,9 @@ module "deep" {
   for_each = local._root_module_stack_configs
   # Stack configuration will take precedence and overwrite the conflicting value from the common configuration (if any)
   maps = [local._common_configs[each.value.root_module], each.value]
+
+  # To support merging labels from common.yaml, we need lists to append instead of overwrite
+  append_list_enabled = true
 }
 
 resource "spacelift_stack" "default" {


### PR DESCRIPTION
## what

- Adds [`append_list_enabled`](https://github.com/cloudposse/terraform-yaml-config/tree/main#input_append_list_enabled) and set to `true` for our usage of Cloud Posse's deep merge module. 

## why

- This fixes an issue a client is having where the labels that they're providing in `stacks/common.yaml` are being overwritten by the stack specific labels in their `stacks/<stack_file_name>.yaml`, which is not desired. The labels should be concatenated together, not overwrite. 

## references

- [Masterpoint Slack Thread (internal)](https://masterpoint.slack.com/archives/C082M39JP6F/p1734045683960079?thread_ts=1733874704.710449&cid=C082M39JP6F)
