### PR TITLE
fix: pass github_enterprise.id to stacks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -272,6 +272,7 @@ resource "spacelift_stack" "default" {
     for_each = var.github_enterprise != null ? [var.github_enterprise] : []
     content {
       namespace = github_enterprise.value["namespace"]
+      id        = github_enterprise.value["id"]
     }
   }
 


### PR DESCRIPTION
## what

* Pass the `github_enterprise.id` value to the `github_enterprise` block

## why

- This is needed so consumers can provide both `namespace` and `id` for the `github_enterprise` config

## references

- [Internal Slack Thread](https://masterpoint.slack.com/archives/C082M39JP6F/p1734572209563439)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new attribute for GitHub Enterprise integration, allowing for the specification of an ID.
  
- **Bug Fixes**
	- Added a precondition to ensure the required configuration file is present before stack creation, improving error handling. 

- **Documentation**
	- Clarified the use of the `deactivated` attribute in the `spacelift_stack_destructor` resource to prevent unintended toggling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->