### PR TITLE
fix: check if tfvars file exists only if when it's expected

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ resource "spacelift_stack" "default" {
   lifecycle {
     # Expected `tfvars` file exists
     precondition {
-      condition     = fileexists("${local.configs[each.key].project_root}/tfvars/${local.configs[each.key].tfvars_file_name}.tfvars")
+      condition     = try(local.configs[each.key].tfvars.enabled, true) ? fileexists("${local.configs[each.key].project_root}/tfvars/${local.configs[each.key].tfvars_file_name}.tfvars") : true
       error_message = <<-EOT
       The required .tfvars file is missing for stack "${each.key}".
 


### PR DESCRIPTION
## what

- If tfvars are not enabled, we should not check this file in precondition.

## why

- Bug.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in stack configuration by allowing stacks to proceed without requiring a `.tfvars` file if not enabled.
	- Improved handling of various stack configurations, including `administrative`, `after_apply`, and `before_init`.

- **Bug Fixes**
	- Refined conditions for the creation of stack resources based on integration and drift detection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->