### PR TITLE
chore: adds a TF testing workflow + changes renovate schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,8 @@
     "config:recommended",
     "github>aquaproj/aqua-renovate-config#2.6.0"
   ],
-  "schedule": ["before 5am on Monday"],
+  // Schedule once a month on the first day of the month before 4 AM.
+  "schedule": ["* 0-3 1 * *"],
   "baseBranches": ["main", "master"],
   "labels": ["auto-upgrade"],
   "dependencyDashboardAutoclose": true,

--- a/.github/workflows/tf-test.yaml
+++ b/.github/workflows/tf-test.yaml
@@ -1,10 +1,9 @@
-name: Terraform + OpenTofu Tests
+name: TF Test
 
 on:
   push:
     branches:
       - main
-      - chore/add-test-pipeline
   pull_request:
 
 env:

--- a/.github/workflows/tf-test.yaml
+++ b/.github/workflows/tf-test.yaml
@@ -18,8 +18,12 @@ permissions:
   pull-requests: read
 
 jobs:
-  terraform-test:
+  tf-test:
+    name: ${{ matrix.tf }} Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tf: [tofu, terraform]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,33 +43,7 @@ jobs:
 
       - name: Aqua Install
         shell: bash
-        run: aqua install --tags terraform
+        run: aqua install --tags ${{ matrix.tf }}
 
-      - run: terraform init
-      - run: terraform test
-
-  tofu-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Aqua Cache
-        uses: actions/cache@v4.0.2
-        if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing
-        with:
-          path: ~/.local/share/aquaproj-aqua
-          key: v1-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
-          restore-keys: |
-            v1-aqua-installer-${{runner.os}}-${{runner.arch}}-
-
-      - name: Install Aqua
-        uses: aquaproj/aqua-installer@4551ec64e21bf0f557c2525135ff0bd2cba40ec7 # v3.0.0
-        with:
-          aqua_version: v2.25.2
-
-      - name: Aqua Install
-        shell: bash
-        run: aqua install --tags tofu
-
-      - run: tofu init
-      - run: tofu test
+      - run: ${{ matrix.tf }} init
+      - run: ${{ matrix.tf }} test

--- a/.github/workflows/tf-test.yaml
+++ b/.github/workflows/tf-test.yaml
@@ -22,6 +22,8 @@ jobs:
   terraform-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Aqua Cache
         uses: actions/cache@v4.0.2
         if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing
@@ -46,6 +48,8 @@ jobs:
   tofu-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Aqua Cache
         uses: actions/cache@v4.0.2
         if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing

--- a/.github/workflows/tf-test.yaml
+++ b/.github/workflows/tf-test.yaml
@@ -1,0 +1,68 @@
+name: Terraform + OpenTofu Tests
+
+on:
+  push:
+    branches:
+      - main
+      - chore/add-test-pipeline
+  pull_request:
+
+env:
+  SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+  SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  id-token: write
+  pull-requests: read
+
+jobs:
+  terraform-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aqua Cache
+        uses: actions/cache@v4.0.2
+        if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing
+        with:
+          path: ~/.local/share/aquaproj-aqua
+          key: v1-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
+          restore-keys: |
+            v1-aqua-installer-${{runner.os}}-${{runner.arch}}-
+
+      - name: Install Aqua
+        uses: aquaproj/aqua-installer@4551ec64e21bf0f557c2525135ff0bd2cba40ec7 # v3.0.0
+        with:
+          aqua_version: v2.25.2
+
+      - name: Aqua Install
+        shell: bash
+        run: aqua install --tags terraform
+
+      - run: terraform init
+      - run: terraform test
+
+  tofu-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aqua Cache
+        uses: actions/cache@v4.0.2
+        if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing
+        with:
+          path: ~/.local/share/aquaproj-aqua
+          key: v1-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
+          restore-keys: |
+            v1-aqua-installer-${{runner.os}}-${{runner.arch}}-
+
+      - name: Install Aqua
+        uses: aquaproj/aqua-installer@4551ec64e21bf0f557c2525135ff0bd2cba40ec7 # v3.0.0
+        with:
+          aqua_version: v2.25.2
+
+      - name: Aqua Install
+        shell: bash
+        run: aqua install --tags tofu
+
+      - run: tofu init
+      - run: tofu test

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,5 +12,7 @@ registries:
 packages:
   - name: terraform-docs/terraform-docs@v0.19.0
   - name: hashicorp/terraform@v1.10.3
+    tags: [terraform]
   - name: opentofu/opentofu@v1.8.7
+    tags: [tofu]
   - name: spacelift-io/spacectl@v1.8.0

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,3 +1,7 @@
+provider "spacelift" {
+  api_key_endpoint = "https://masterpointio.app.spacelift.io"
+}
+
 variables {
   root_modules_path = "./tests/fixtures"
   common_config_file = "common.yaml"


### PR DESCRIPTION
## what

- Adds a tf-test workflow for running terraform + tofu tests

## why

- This will ensure we're always running tests on each PR to make sure we don't break anything

## references

- N/A
