### PR TITLE
feat: allow project root to be customized for stack

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,8 @@ locals {
     local._multi_instance_structure ? "${module}-${trimsuffix(file, ".yaml")}" : module =>
     merge(
       {
-        "project_root" = replace(format("%s/%s", var.root_modules_path, module), "../", "")
+        # Use specified project_root, if not, build it using the root_modules_path and module name
+        "project_root" = try(content.project_root, replace(format("%s/%s", var.root_modules_path, module), "../", ""))
         "root_module"  = module,
 
         # If default_tf_workspace_enabled is true, use "default" workspace, otherwise our file name is the workspace name

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ locals {
     merge(
       {
         # Use specified project_root, if not, build it using the root_modules_path and module name
-        "project_root" = try(content.project_root, replace(format("%s/%s", var.root_modules_path, module), "../", ""))
+        "project_root" = try(content.stack_settings.project_root, replace(format("%s/%s", var.root_modules_path, module), "../", "")),
         "root_module"  = module,
 
         # If default_tf_workspace_enabled is true, use "default" workspace, otherwise our file name is the workspace name

--- a/tests/fixtures/single-instance/root-module-b/stack.yaml
+++ b/tests/fixtures/single-instance/root-module-b/stack.yaml
@@ -1,0 +1,7 @@
+stack_settings:
+  administrative: false
+  before_init:
+    - echo 'World'
+  labels:
+    - stack_label
+  project_root: "" # root directory of the project

--- a/tests/fixtures/single-instance/root-module-b/stack.yaml
+++ b/tests/fixtures/single-instance/root-module-b/stack.yaml
@@ -4,4 +4,4 @@ stack_settings:
     - echo 'World'
   labels:
     - stack_label
-  project_root: "" # root directory of the project
+  project_root: "" # Root directory of the project. This means that Spacelift will pull the entire repository and run the stack from the root of the repository.

--- a/tests/single-instance.tftest.hcl
+++ b/tests/single-instance.tftest.hcl
@@ -46,7 +46,7 @@ run "test_single_instance_stack_configs_stack_name_is_correct" {
   command = plan
 
   assert {
-    condition = length(local._root_module_stack_configs) == 1 && local._root_module_stack_configs["root-module-a"] != null
+    condition = length(local._root_module_stack_configs) == 2 && local._root_module_stack_configs["root-module-a"] != null && local._root_module_stack_configs["root-module-b"] != null
     error_message = "_root_module_stack_configs is not expected structure: ${jsonencode(local._root_module_stack_configs)}"
   }
 }
@@ -73,7 +73,7 @@ run "test_single_instance_stack_configs_custom_project_root_is_used_when_specifi
   command = plan
 
   assert {
-    # root-module-b's stack.yaml specifies `project_root` as "" to indicate root directory of project as source
+    # `tests/fixtures/single-instance/root-module-b/stack.yaml` specifies `project_root` as "" to indicate root directory of project as source.
     condition = local._root_module_stack_configs["root-module-b"].project_root == ""
     error_message = "Custom project_root not used: ${jsonencode(local._root_module_stack_configs)}"
   }

--- a/tests/single-instance.tftest.hcl
+++ b/tests/single-instance.tftest.hcl
@@ -69,6 +69,16 @@ run "test_single_instance_stack_configs_project_root_is_correct" {
   }
 }
 
+run "test_single_instance_stack_configs_custom_project_root_is_used_when_specified" {
+  command = plan
+
+  assert {
+    # root-module-b's stack.yaml specifies `project_root` as "" to indicate root directory of project as source
+    condition = local._root_module_stack_configs["root-module-b"].project_root == ""
+    error_message = "Custom project_root not used: ${jsonencode(local._root_module_stack_configs)}"
+  }
+}
+
 # Test that the administrative label is not added to the stack when the stack is not set to administrative
 run "test_single_instance_administrative_label_is_not_added_to_stack_when_not_administrative" {
   command = plan


### PR DESCRIPTION
## what

- Allows the `project_root` to be specified for each stack, in their respective `stack.yaml` or `common.yaml` files. 

## why

- By default, the logic right now to build the path using the root module path then the name of the module, but certain Terraform tools like Terraspace requires the entire project to be pulled in order to access other files in the repo's root directory. 
- Adds tests.

## references

- https://github.com/masterpointio/terraform-spacelift-automation/pull/17#discussion_r1898030010
- 
![image](https://github.com/user-attachments/assets/eafc38c3-03ab-480a-8c4e-31937af6316d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `stack_settings` configuration section to enhance stack configuration capabilities
  - Introduced support for pre-initialization commands, stack labeling, and custom project root specification

- **Tests**
  - Updated test suite to validate multiple root module stack configurations
  - Added new test case to verify custom project root handling

- **Improvements**
  - Enhanced error handling for stack configuration retrieval
  - Improved robustness of Terraform configuration logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->