### PR TITLE
feat!(schema): adds initial JSON schema + Stack Config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,39 @@ Check out an example configuration in the [examples/complete](./examples/complet
 
 <!-- NOTE to Masterpoint team: We might want to create a small wrapper to automatize this using Taskit. On hold for now. -->
 
-### What goes in a Stack config file? e.g. `stacks/dev.yaml`, `stacks/common.yaml`, `stack.yaml`, etc
+### What goes in a Stack config file? e.g. `stacks/dev.yaml`, `stacks/common.yaml`, `stack.yaml`, and similar
 
-Most settings that you would set on [the Spacelift Stack resource](https://search.opentofu.org/provider/spacelift-io/spacelift/latest/docs/resources/stack) are supported. Additionally, you can include certain Stack specific settings that will override this module's defaults like `default_tf_workspace_enabled`, `tfvars.enabled`, and similar. See the code for full details.
+Most settings that you would set on [the Spacelift Stack resource](https://search.opentofu.org/provider/spacelift-io/spacelift/latest/docs/resources/stack) are supported. Additionally, you can include certain automation settings that will override this module's defaults like `automation_settings.default_tf_workspace_enabled`, `automation_settings.tfvars_enabled`, and similar.
+
+Below is a brief example. You can also see the full schema in our [JSON Schema file](./stack-config.schema.json).
+
+```yaml
+kind: StackConfigV1
+stack_settings:
+  administrative: true
+  autodeploy: true
+  autoretry: true
+  description: "Production EKS cluster configuration"
+  labels:
+    - "prod"
+
+  terraform_version: "1.9.0"
+  terraform_workflow_tool: "OPEN_TOFU"
+
+  # Security and protection
+  protect_from_deletion: true
+  enable_local_preview: false
+
+  # Hooks and scripts
+  before_init:
+    - "echo hello-world"
+  after_apply:
+    - "./scripts/notify-slack.sh"
+
+automation_settings:
+  default_tf_workspace_enabled: true
+  tfvars_enabled: false
+```
 
 ### Why are variable values provided separately in `tfvars/` and not in the `yaml` file?
 

--- a/examples/complete/root-modules/network/stacks/dev.yaml
+++ b/examples/complete/root-modules/network/stacks/dev.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   description: Create the VPC + Subnets for the Dev environment
   labels:

--- a/examples/complete/root-modules/network/stacks/prod.yaml
+++ b/examples/complete/root-modules/network/stacks/prod.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   description: Create the VPC + Subnets for the Prod environment
   labels:

--- a/examples/complete/root-modules/random-pet/stacks/common.yaml
+++ b/examples/complete/root-modules/random-pet/stacks/common.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   manage_state: true
   labels:

--- a/examples/complete/root-modules/random-pet/stacks/dev.yaml
+++ b/examples/complete/root-modules/random-pet/stacks/dev.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   description: This stack is used to create a random pet name for Prod!
   labels:

--- a/examples/complete/root-modules/random-pet/stacks/prod.yaml
+++ b/examples/complete/root-modules/random-pet/stacks/prod.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   description: This stack is used to create a random pet name for Prod!
   labels:

--- a/examples/complete/root-modules/spacelift-automation/stacks/common.yaml
+++ b/examples/complete/root-modules/spacelift-automation/stacks/common.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   administrative: true
   description: This Automation stack is used for Masterpoint's testing purposes
@@ -5,8 +6,9 @@ stack_settings:
     - common_label
   drift_detection_enabled: true
 
-# There is only one instance of this spacelift-automation stack, so we can use the default TF workspace instead of creating a new one.
-default_tf_workspace_enabled: true
+automation_settings:
+  # There is only one instance of this spacelift-automation stack, so we can use the default TF workspace instead of creating a new one.
+  default_tf_workspace_enabled: true
 
-tfvars:
-  enabled: false
+  # We don't need to load tfvars for this stack.
+  tfvars_enabled: false

--- a/examples/single-instance/root-modules/random-pet/stack.yaml
+++ b/examples/single-instance/root-modules/random-pet/stack.yaml
@@ -1,7 +1,9 @@
+kind: StackConfigV1
 stack_settings:
   manage_state: true
   description: This stack generates random pet names
   labels:
     - common_label
     - stack_specific_label
-default_tf_workspace_enabled: true
+automation_settings:
+  default_tf_workspace_enabled: true

--- a/examples/single-instance/root-modules/rds-cluster-dev/stack.yaml
+++ b/examples/single-instance/root-modules/rds-cluster-dev/stack.yaml
@@ -1,2 +1,3 @@
+kind: StackConfigV1
 stack_settings:
   description: This is a mock root module for Dev

--- a/examples/single-instance/root-modules/rds-cluster-prod/stack.yaml
+++ b/examples/single-instance/root-modules/rds-cluster-prod/stack.yaml
@@ -1,2 +1,3 @@
+kind: StackConfigV1
 stack_settings:
   description: This is a mock root module for Prod

--- a/examples/single-instance/root-modules/spacelift-automation-example2/stack.yaml
+++ b/examples/single-instance/root-modules/spacelift-automation-example2/stack.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   description: This Automation stack is used for Masterpoint's testing purposes
   administrative: true
@@ -5,4 +6,5 @@ stack_settings:
   labels:
     - common_label
     - stack_specific_label
-default_tf_workspace_enabled: true
+automation_settings:
+  default_tf_workspace_enabled: true

--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ locals {
         "root_module"  = module,
 
         # If default_tf_workspace_enabled is true, use "default" workspace, otherwise our file name is the workspace name
-        "terraform_workspace" = try(content.default_tf_workspace_enabled, local._default_tf_workspace_enabled) ? "default" : trimsuffix(file, ".yaml"),
+        "terraform_workspace" = try(content.automation_settings.default_tf_workspace_enabled, local._default_tf_workspace_enabled) ? "default" : trimsuffix(file, ".yaml"),
 
         # tfvars_file_name only pertains to MultiInstance, as SingleInstance expects consumers to use an auto.tfvars file.
         # `yaml` is intentionally used here as we require Stack and `tfvars` config files to be named equally
@@ -253,7 +253,7 @@ locals {
     for stack in local.stacks : stack =>
     # tfvars are implicitly enabled in MultiInstance, which means we include the tfvars copy command in before_init
     # In SingleInstance, we expect the consumer to use an auto.tfvars file, so we don't include the tfvars copy command in before_init
-    try(local.configs[stack].tfvars.enabled, local._multi_instance_structure) ?
+    try(local.configs[stack].automation_settings.tfvars_enabled, local._multi_instance_structure) ?
     compact(concat(
       var.before_init,
       try(local.stack_configs[stack].before_init, []),

--- a/stack-config.schema.json
+++ b/stack-config.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://json.schemastore.org/masterpoint-spacelift-automation-stack-config.json",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true
+  },
+  "title": "Masterpoint Stack Config schema. Version 1.0. https://masterpoint.io",
+  "description": "Schema for Masterpoint's spacelift-automation stack configuration files. This is used to override stack configurations for the https://github.com/masterpointio/terraform-spacelift-automation module.",
+  "type": "object",
+  "required": ["kind", "stack_settings"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["StackConfigV1"],
+      "description": "The type of configuration file"
+    },
+    "automation_settings": {
+      "type": "object",
+      "description": "Settings that control the automation behavior of the stack",
+      "properties": {
+        "default_tf_workspace_enabled": {
+          "type": "boolean",
+          "description": "Whether to use the default terraform workspace"
+        },
+        "tfvars_enabled": {
+          "type": "boolean",
+          "description": "Whether to enable tfvars file loading"
+        }
+      }
+    },
+    "stack_settings": {
+      "type": "object",
+      "description": "Core stack settings, these overwrite the defaults set in the spacelift-automation module",
+      "properties": {
+        "administrative": {
+          "type": "boolean",
+          "description": "Whether the stack is administrative"
+        },
+        "additional_project_globs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional file patterns to trigger stack operations"
+        },
+        "after_apply": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after apply"
+        },
+        "after_destroy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after destroy"
+        },
+        "after_init": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after init"
+        },
+        "after_perform": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after perform"
+        },
+        "after_plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after plan"
+        },
+        "autodeploy": {
+          "type": "boolean",
+          "description": "Whether to automatically deploy changes"
+        },
+        "autoretry": {
+          "type": "boolean",
+          "description": "Whether to automatically retry failed runs"
+        },
+        "before_apply": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run before apply"
+        },
+        "before_destroy": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run before destroy"
+        },
+        "before_init": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run before init"
+        },
+        "before_perform": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run before perform"
+        },
+        "before_plan": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run before plan"
+        },
+        "branch": {
+          "type": "string",
+          "description": "Git branch to track"
+        },
+        "description": {
+          "type": "string",
+          "description": "Stack description"
+        },
+        "enable_local_preview": {
+          "type": "boolean",
+          "description": "Whether to enable local preview"
+        },
+        "enable_well_known_secret_masking": {
+          "type": "boolean",
+          "description": "Whether to enable masking of well-known secrets"
+        },
+        "github_action_deploy": {
+          "type": "boolean",
+          "description": "Whether to enable GitHub Action deployment"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Custom labels for the stack, these merge with the default labels set in the spacelift-automation module"
+        },
+        "manage_state": {
+          "type": "boolean",
+          "description": "Whether Spacelift should manage the state"
+        },
+        "project_root": {
+          "type": "string",
+          "description": "Root directory of the project"
+        },
+        "protect_from_deletion": {
+          "type": "boolean",
+          "description": "Whether to protect the stack from deletion"
+        },
+        "repository": {
+          "type": "string",
+          "description": "Git repository URL"
+        },
+        "runner_image": {
+          "type": "string",
+          "description": "Docker image for the runner"
+        },
+        "space_id": {
+          "type": "string",
+          "description": "Spacelift space ID"
+        },
+        "terraform_smart_sanitization": {
+          "type": "boolean",
+          "description": "Whether to enable smart sanitization"
+        },
+        "terraform_version": {
+          "type": "string",
+          "description": "Terraform version to use"
+        },
+        "worker_pool_id": {
+          "type": "string",
+          "description": "Worker pool ID"
+        },
+        "aws_integration_enabled": {
+          "type": "boolean",
+          "description": "Whether to enable AWS integration"
+        },
+        "aws_integration_id": {
+          "type": "string",
+          "description": "AWS integration ID"
+        },
+        "drift_detection_enabled": {
+          "type": "boolean",
+          "description": "Whether to enable drift detection"
+        },
+        "drift_detection_ignore_state": {
+          "type": "boolean",
+          "description": "Whether to ignore state in drift detection"
+        },
+        "drift_detection_reconcile": {
+          "type": "boolean",
+          "description": "Whether to reconcile drift automatically"
+        },
+        "drift_detection_schedule": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^([0-9,\\-\\*]+\\s+){4}[0-9,\\-\\*]+$"
+          },
+          "description": "Cron schedule for drift detection"
+        },
+        "drift_detection_timezone": {
+          "type": "string",
+          "description": "Timezone for drift detection schedule"
+        },
+        "destructor_enabled": {
+          "type": "boolean",
+          "description": "Whether to enable the stack destructor"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/multi-instance/root-module-a/stacks/common.yaml
+++ b/tests/fixtures/multi-instance/root-module-a/stacks/common.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   administrative: false
   labels:

--- a/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
+++ b/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
@@ -1,11 +1,10 @@
+kind: StackConfigV1
 stack_settings:
   administrative: true
   before_init:
     - echo 'World'
   labels:
     - default_example_label
-
-default_tf_workspace_enabled: true
-
-tfvars:
-  enabled: false
+automation_settings:
+  default_tf_workspace_enabled: true
+  tfvars_enabled: false

--- a/tests/fixtures/multi-instance/root-module-a/stacks/test.yaml
+++ b/tests/fixtures/multi-instance/root-module-a/stacks/test.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   labels:
     - test_label

--- a/tests/fixtures/single-instance/root-module-a/stack.yaml
+++ b/tests/fixtures/single-instance/root-module-a/stack.yaml
@@ -1,3 +1,4 @@
+kind: StackConfigV1
 stack_settings:
   administrative: false
   before_init:


### PR DESCRIPTION
## what

- 3 Stack Config schema changes: 
  - Scopes `default_tf_workspace_enabled` under `automation_settings`
  - Renames `tfvars.enabled` to `tfvars_enabled` and scopes under `automation_settings`
  - Adds `kind` so we can manage version / have a formal name for these configs
- Adds a JSON schema for StackConfig
- Updates + docs to support these changes

## why

- Provides a clear separation between stack settings + spacelift automation module settings.
- We don't have any other `tfvars` settings... and if we do they can be separate?
- JSON schema will help clients + us validate their configurations and give us a clear indicator when things fail

## references

- [Internal Slack thread on this topic](https://masterpoint.slack.com/archives/C04MUCKUDKK/p1737218799733849).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md with clearer descriptions of Stack configuration files
	- Added example YAML configuration to illustrate stack settings

- **Configuration Updates**
	- Introduced `kind: StackConfigV1` across multiple stack configuration files
	- Added new `automation_settings` section in various stack configurations
	- Reorganized settings for Terraform workspace and TFVars management

- **Schema**
	- Created new JSON schema for stack configuration to provide structured guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->