### PR TITLE
fix: external space changed so update test data

### DIFF
--- a/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
+++ b/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
@@ -22,7 +22,7 @@ stack_settings:
   manage_state: true
   protect_from_deletion: true
   runner_image: masterpointio/spacelift-runner:latest
-  space_name: mp-automation # Tests space_name gets translated to space_id (the Terraform resource attribute that is accepted)
+  space_name: mp-aws-automation # Tests space_name gets translated to space_id (the Terraform resource attribute that is accepted)
   terraform_smart_sanitization: true
   terraform_version: 1.9.0
   worker_pool_id: "1234567890"

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -154,7 +154,7 @@ run "test_default_example_stack_final_values" {
 
   # space_id
   assert {
-    condition = spacelift_stack.default["root-module-a-default-example"].space_id == "mp-automation-01JEC2D4K2Q2V1AJQ0Y6BFGJJ3"
+    condition = spacelift_stack.default["root-module-a-default-example"].space_id == "mp-aws-automation-01JK7A21DW1YH3Q64JHS3RYNP9"
     error_message = "space_id was not correct on the default-example stack: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
   }
 
@@ -604,7 +604,7 @@ run "test_default_example_stack_partial_runtime_overrides" {
 
   # space_id
   assert {
-    condition = spacelift_stack.default["root-module-a-default-example"].space_id == "mp-automation-01JEC2D4K2Q2V1AJQ0Y6BFGJJ3"
+    condition = spacelift_stack.default["root-module-a-default-example"].space_id == "mp-aws-automation-01JK7A21DW1YH3Q64JHS3RYNP9"
     error_message = "space_id was not correct on the default-example stack: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
   }
 
@@ -841,7 +841,7 @@ run "test_space_name_resolves_to_correct_id" {
   command = plan
 
   assert {
-    condition     = local.resolved_space_ids["root-module-a-default-example"] == "mp-automation-01JEC2D4K2Q2V1AJQ0Y6BFGJJ3" # For the `masterpointio.app.spacelift.io`
+    condition     = local.resolved_space_ids["root-module-a-default-example"] == "mp-aws-automation-01JK7A21DW1YH3Q64JHS3RYNP9" # For the `masterpointio.app.spacelift.io`
     error_message = "Space name not resolving to correct ID: ${jsonencode(local.resolved_space_ids)}"
   }
 }


### PR DESCRIPTION
## what

- Changes test data to match our new Space ID (external in the `masterpointio` Spacelift)

## why

- I mucked around with Spaces when integration testing this module... and then broke this as a result 😅 

## references

- See internal change: https://github.com/masterpointio/mp-infra/pull/52 
