### PR TITLE
feat: add spacelift stack's `after_run` config, FINALLY hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This is to support easy local and outside-spacelift operations. Keeping variable
 | Name | Version |
 |------|---------|
 | <a name="provider_jsonschema"></a> [jsonschema](#provider\_jsonschema) | 0.2.1 |
-| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | 1.19.1 |
+| <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | 1.19.0 |
 
 ## Modules
 
@@ -269,6 +269,7 @@ This is to support easy local and outside-spacelift operations. Keeping variable
 | <a name="input_after_init"></a> [after\_init](#input\_after\_init) | List of after-init scripts | `list(string)` | `[]` | no |
 | <a name="input_after_perform"></a> [after\_perform](#input\_after\_perform) | List of after-perform scripts | `list(string)` | `[]` | no |
 | <a name="input_after_plan"></a> [after\_plan](#input\_after\_plan) | List of after-plan scripts | `list(string)` | `[]` | no |
+| <a name="input_after_run"></a> [after\_run](#input\_after\_run) | List of after-run (aka `finally` hook) scripts | `list(string)` | `[]` | no |
 | <a name="input_all_root_modules_enabled"></a> [all\_root\_modules\_enabled](#input\_all\_root\_modules\_enabled) | When set to true, all subdirectories in root\_modules\_path will be treated as root modules. | `bool` | `false` | no |
 | <a name="input_autodeploy"></a> [autodeploy](#input\_autodeploy) | Flag to enable/disable automatic deployment of the stack | `bool` | `true` | no |
 | <a name="input_autoretry"></a> [autoretry](#input\_autoretry) | Flag to enable/disable automatic retry of the stack | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -329,6 +329,7 @@ resource "spacelift_stack" "default" {
   after_init                       = compact(concat(try(local.stack_configs[each.key].after_init, []), var.after_init))
   after_perform                    = compact(concat(try(local.stack_configs[each.key].after_perform, []), var.after_perform))
   after_plan                       = compact(concat(try(local.stack_configs[each.key].after_plan, []), var.after_plan))
+  after_run                        = compact(concat(try(local.stack_configs[each.key].after_run, []), var.after_run))
   autodeploy                       = coalesce(try(local.stack_configs[each.key].autodeploy, null), var.autodeploy)
   autoretry                        = try(local.stack_configs[each.key].autoretry, var.autoretry)
   before_apply                     = compact(coalesce(try(local.stack_configs[each.key].before_apply, []), var.before_apply))

--- a/stack-config.schema.json
+++ b/stack-config.schema.json
@@ -80,6 +80,13 @@
           },
           "description": "Commands to run after plan"
         },
+        "after_run": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Commands to run after run (aka `finally` hook)."
+        },
         "autodeploy": {
           "type": "boolean",
           "description": "Whether to automatically deploy changes"

--- a/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
+++ b/tests/fixtures/multi-instance/root-module-a/stacks/default-example.yaml
@@ -7,6 +7,7 @@ stack_settings:
   after_init: [echo 'after_init']
   after_perform: [echo 'after_perform']
   after_plan: [echo 'after_plan']
+  after_run: [echo 'after_run']
   autodeploy: false
   autoretry: true
   before_apply: [echo 'before_apply']

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -62,6 +62,12 @@ run "test_default_example_stack_final_values" {
     error_message = "after_plan was not correct on the default-example stack: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
   }
 
+  # after_run
+  assert {
+    condition = contains(spacelift_stack.default["root-module-a-default-example"].after_run, "echo 'after_run'")
+    error_message = "after_run was not correct on the default-example stack: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
+  }
+
   # autodeploy
   assert {
     condition = spacelift_stack.default["root-module-a-default-example"].autodeploy == false
@@ -228,6 +234,7 @@ run "test_default_example_stack_runtime_overrides" {
           after_init = ["echo 'changed_after_init'"]
           after_perform = ["echo 'changed_after_perform'"]
           after_plan = ["echo 'changed_after_plan'"]
+          after_run = ["echo 'changed_after_run'"]
           autodeploy = true
           autoretry = false
           before_apply = ["echo 'changed_before_apply'"]
@@ -303,6 +310,12 @@ run "test_default_example_stack_runtime_overrides" {
   assert {
     condition = contains(spacelift_stack.default["root-module-a-default-example"].after_plan, "echo 'changed_after_plan'")
     error_message = "after_plan override was not applied correctly: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
+  }
+
+  # after_run
+  assert {
+    condition = contains(spacelift_stack.default["root-module-a-default-example"].after_run, "echo 'changed_after_run'")
+    error_message = "after_run override was not applied correctly: ${jsonencode(spacelift_stack.default["root-module-a-default-example"])}"
   }
 
   # autodeploy

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,12 @@ variable "after_plan" {
   default     = []
 }
 
+variable "after_run" {
+  type        = list(string)
+  description = "List of after-run (aka `finally` hook) scripts"
+  default     = []
+}
+
 variable "autodeploy" {
   type        = bool
   description = "Flag to enable/disable automatic deployment of the stack"


### PR DESCRIPTION
## what

Allow the `after_run` (FINALLY hook) to be set for Spacelift stacks.

## why

For use cases when a script is needed to be ran even if the apply/deployment doesn't go through. Similar to the try catch, finally.

## references
https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack#after_run-1
![image](https://github.com/user-attachments/assets/f31a4fef-4b9c-479f-899f-cc1335bc283f)

