### PR TITLE
fix: pin tofu 1.8 due to usage of .tofu extension

### DIFF
--- a/versions.tofu
+++ b/versions.tofu
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.7"
+  required_version = ">= 1.8"
 
   required_providers {
     spacelift = {


### PR DESCRIPTION
## what

- Pin OpenTofu 1.8 as required version

## why

- Well... this was a doh moment on my part: we're using the `.tofu` extension to specify that our required OpenTofu version is 1.7, but OpenTofu version 1.8 is when the `.tofu` extension got introduced so it needs to pin that version for the correct `versions.*` file to get picked up. 
<img src="https://media1.giphy.com/media/v1.Y2lkPWJkM2VhNTdlaXZ0cHAyZW9hZ2oyZW5sdWJpa21zNzhybjQ3M2ZoYXVrZWF4dGxtNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT5LMzIK1AdZJ4cYW4/giphy.gif"/>

## references

- [Internal Slack Thread on this Topic](https://masterpoint.slack.com/archives/C079XUPRCFQ/p1739317723223799?thread_ts=1739312471.525849&cid=C079XUPRCFQ)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- The minimum required Terraform version has been updated from 1.7 to 1.8. This change ensures that users benefit from recent improvements and compatibility enhancements. Please verify that your environment aligns with the new version requirement for continued optimal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->