### PR TITLE
fix(gha): trigger test workflow on pull_request_target

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 env:
   SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}


### PR DESCRIPTION
## what

- Updates workflow trigger to pull_request_target.

## why

- If the PR is created from a fork, the GITHUB_TOKEN will have read-only permissions and will not have access to secrets (e.g., secrets.GITHUB_TOKEN or custom secrets). Actions like writing to the repository (e.g., pushing commits, creating tags) will not work because the token won't have write permissions.
- This is a security measure to prevent unauthorized access to sensitive information when workflows are triggered by untrusted contributors. Fork pull requests from users without write access will require approval to run workflows due to GH Org configuration.

## references

- Similar issue https://github.com/masterpointio/terraform-aws-ssm-agent/pull/40
