### PR TITLE
feat: add spaces as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ This is to support easy local and outside-spacelift operations. Keeping variable
 
 | Name | Description |
 |------|-------------|
+| <a name="output_spacelift_spaces"></a> [spacelift\_spaces](#output\_spacelift\_spaces) | A map of Spacelift Spaces with relevant attributes. |
 | <a name="output_spacelift_stacks"></a> [spacelift\_stacks](#output\_spacelift\_stacks) | A map of Spacelift stacks with selected attributes.<br/>To reduce the risk of accidentally exporting sensitive data, only a subset of attributes is exported. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable -->

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ This is to support easy local and outside-spacelift operations. Keeping variable
 
 | Name | Description |
 |------|-------------|
-| <a name="output_spacelift_spaces"></a> [spacelift\_spaces](#output\_spacelift\_spaces) | A map of Spacelift Spaces with relevant attributes. |
+| <a name="output_spacelift_spaces"></a> [spacelift\_spaces](#output\_spacelift\_spaces) | A map of Spacelift spaces with all their attributes. |
 | <a name="output_spacelift_stacks"></a> [spacelift\_stacks](#output\_spacelift\_stacks) | A map of Spacelift stacks with selected attributes.<br/>To reduce the risk of accidentally exporting sensitive data, only a subset of attributes is exported. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,17 @@ output "spacelift_stacks" {
     }
   }
 }
+
+output "spacelift_spaces" {
+  description = "A map of Spacelift Spaces with relevant attributes."
+  value = {
+    for name, space in spacelift_space.default : name => {
+      id               = space.id
+      name             = space.name
+      description      = space.description
+      inherit_entities = space.inherit_entities
+      labels           = space.labels
+      parent_space_id  = space.parent_space_id
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,15 +14,8 @@ output "spacelift_stacks" {
 }
 
 output "spacelift_spaces" {
-  description = "A map of Spacelift Spaces with relevant attributes."
+  description = "A map of Spacelift spaces with all their attributes."
   value = {
-    for name, space in spacelift_space.default : name => {
-      id               = space.id
-      name             = space.name
-      description      = space.description
-      inherit_entities = space.inherit_entities
-      labels           = space.labels
-      parent_space_id  = space.parent_space_id
-    }
+    for name, space in spacelift_space.default : name => space
   }
 }


### PR DESCRIPTION
Add `spacelift_spaces` as an output, similarly to the `spacelift_stacks` output.

Good for reference, and in case there is a need to reference the ID of the space in Terraform (e.g. `space_id = module.spacelift.spacelift_spaces["dev"].id`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public output that exposes a map of Spacelift Spaces, including key attributes such as id, name, description, labels, inheritance settings, and parent space ID.
* **Documentation**
  * Updated the public API and Outputs sections to include and describe the new Spacelift Spaces output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->