### PR TITLE
feat(stack_name_template): allow reformatting stack ids

### DIFF
--- a/.trunk/configs/.hadolint.yaml
+++ b/.trunk/configs/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Following source doesn't work in most setups
+ignored:
+  - SC1090
+  - SC1091

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.2
+      ref: v1.7.4
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,16 +20,17 @@ lint:
     # Incompatible with some Terraform features: https://github.com/tenable/terrascan/issues/1331
     - terrascan
   enabled:
-    - renovate@41.132.2
-    - tofu@1.10.6
-    - actionlint@1.7.7
-    - checkov@3.2.473
+    - hadolint@2.14.0
+    - renovate@42.11.0
+    - tofu@1.10.7
+    - actionlint@1.7.8
+    - checkov@3.2.493
     - git-diff-check
     - markdownlint@0.45.0
     - prettier@3.6.2
     - tflint@0.59.1
-    - trivy@0.67.0
-    - trufflehog@3.90.8
+    - trivy@0.67.2
+    - trufflehog@3.91.0
     - yamllint@1.37.1
   ignore:
     - linters: [tofu]

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -15,3 +15,5 @@ packages:
     tags: [terraform]
   - name: opentofu/opentofu@v1.9.1
     tags: [tofu]
+  - name: trunk-io/launcher
+    version: 1.0.0

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,46 @@ locals {
 
   _root_module_yaml_decoded = merge(local._multi_instance_root_module_yaml_decoded, local._single_instance_root_module_yaml_decoded)
 
+  ## Stack Name Template Resolution
+  # Determine the default template based on structure type
+  # MultiInstance: "${workspace}-${module_path}" (e.g., "dev-network")
+  # SingleInstance: "${module_name}" (e.g., "rds-cluster")
+  default_stack_name_template = local._multi_instance_structure ? "$${workspace}-$${module_path}" : "$${module_name}"
+
+  # Use provided template or fall back to default
+  stack_name_template = coalesce(var.stack_name_template, local.default_stack_name_template)
+
+  # Generate stack names using the template
+  # Iterates over all modules and their stack files, applying the template with available parameters
+  stack_names = {
+    for module, files in local._root_module_yaml_decoded :
+    module => {
+      for file, content in files :
+      file => (
+        file == var.common_config_file ? null :
+        templatestring(
+          local.stack_name_template,
+          {
+            module_name = basename(module)
+            workspace   = trimsuffix(file, ".yaml")
+            module_path = replace(module, "/", "-")
+          }
+        )
+      ) if file != var.common_config_file
+    }
+  }
+
+  # Clean up stack names to handle edge cases
+  # Removes double hyphens, leading/trailing hyphens, and applies trimspace
+  # This handles cases where template parameters may be empty (e.g., SingleInstance with ${workspace})
+  cleaned_stack_names = {
+    for module, names in local.stack_names :
+    module => {
+      for file, name in names :
+      file => name != null ? trimspace(replace(replace(replace(name, "--", "-"), "/^-/", ""), "/-$/", "")) : null
+    }
+  }
+
   ## Common Stack configurations
   # Retrieve common Stack configurations for each root module.
   # SingleInstance root_module_structure does not support common configs today.
@@ -155,7 +195,7 @@ locals {
   # }
   _root_module_stack_configs = merge([for module, files in local._root_module_yaml_decoded : {
     for file, content in files :
-    local._multi_instance_structure ? "${module}-${trimsuffix(file, ".yaml")}" : module =>
+    local.cleaned_stack_names[module][file] =>
     merge(
       {
         # Use specified project_root, if not, build it using the root_modules_path and module name

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ locals {
           {
             module_name = basename(module)
             workspace   = trimsuffix(file, ".yaml")
-            module_path = replace(module, "/", "-")
+            module_path = module
           }
         )
       ) if file != var.common_config_file

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,6 +1,7 @@
 variables {
-  root_modules_path  = "./tests/fixtures/multi-instance"
-  common_config_file = "common.yaml"
+  root_modules_path   = "./tests/fixtures/multi-instance"
+  stack_name_template = "$${module_path}-$${workspace}"
+  common_config_file  = "common.yaml"
   github_enterprise = {
     namespace = "masterpointio"
   }

--- a/tests/nested-directories.tftest.hcl
+++ b/tests/nested-directories.tftest.hcl
@@ -1,5 +1,6 @@
 variables {
-  repository = "terraform-spacelift-automation"
+  repository          = "terraform-spacelift-automation"
+  stack_name_template = "$${module_path}-$${workspace}"
   github_enterprise = {
     namespace = "masterpointio"
   }
@@ -55,7 +56,7 @@ run "test_nested_directory_multi_instance_support" {
   }
 
   assert {
-    condition     = spacelift_stack.default["parent/nested-prod"].branch == "main"  
+    condition     = spacelift_stack.default["parent/nested-prod"].branch == "main"
     error_message = "Nested directory prod stack should have main branch: ${spacelift_stack.default["parent/nested-prod"].branch}"
   }
 }

--- a/tests/resource-id-resolver.tftest.hcl
+++ b/tests/resource-id-resolver.tftest.hcl
@@ -2,8 +2,9 @@
 # name-to-ID resolution for Spacelift resources and when to use global vs stack-level values,
 # including Spaces, Worker Pools, and AWS Integrations, etc.
 variables {
-  root_modules_path  = "./tests/fixtures/multi-instance"
-  common_config_file = "common.yaml"
+  stack_name_template = "$${module_path}-$${workspace}"
+  root_modules_path   = "./tests/fixtures/multi-instance"
+  common_config_file  = "common.yaml"
   github_enterprise = {
     namespace = "masterpointio"
   }
@@ -48,8 +49,8 @@ run "test_global_space_id_variable_is_used" {
   command = plan
 
   variables {
-    space_id = "global-space-id-from-variable"
-    root_modules_path = "./tests/fixtures/single-instance"
+    space_id              = "global-space-id-from-variable"
+    root_modules_path     = "./tests/fixtures/single-instance"
     root_module_structure = "SingleInstance"
   }
 
@@ -64,7 +65,7 @@ run "test_default_space_id_is_used_when_no_values_provided" {
   command = plan
 
   variables {
-    root_modules_path = "./tests/fixtures/single-instance"
+    root_modules_path     = "./tests/fixtures/single-instance"
     root_module_structure = "SingleInstance"
   }
 
@@ -79,7 +80,7 @@ run "test_single_instance_space_id_from_stack_yaml" {
   command = plan
 
   variables {
-    root_modules_path = "./tests/fixtures/single-instance"
+    root_modules_path     = "./tests/fixtures/single-instance"
     root_module_structure = "SingleInstance"
   }
 

--- a/tests/single-instance.tftest.hcl
+++ b/tests/single-instance.tftest.hcl
@@ -1,6 +1,7 @@
 
 variables {
-  root_modules_path = "./tests/fixtures/single-instance"
+  stack_name_template = "$${module_path}-$${workspace}"
+  root_modules_path   = "./tests/fixtures/single-instance"
   github_enterprise = {
     namespace = "masterpointio"
   }

--- a/tests/vcs_integrations.tftest.hcl
+++ b/tests/vcs_integrations.tftest.hcl
@@ -27,6 +27,7 @@ mock_provider "jsonschema" {
 }
 
 variables {
+  stack_name_template      = "$${module_path}-$${workspace}"
   root_modules_path        = "./tests/fixtures/multi-instance"
   common_config_file       = "common.yaml"
   repository               = "terraform-spacelift-automation"
@@ -149,9 +150,9 @@ run "test_vcs_blocks_empty_when_null" {
 
   variables {
     github_enterprise    = null
-    raw_git             = null
-    gitlab              = null
-    bitbucket_cloud     = null
+    raw_git              = null
+    gitlab               = null
+    bitbucket_cloud      = null
     bitbucket_datacenter = null
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -418,6 +418,25 @@ variable "worker_pool_name" {
   default     = null
 }
 
+variable "stack_name_template" {
+  type        = string
+  description = <<-EOT
+    Template for generating stack names. Supports the following parameters:
+    - $${module_name}: The root module directory name (e.g., 'network', 'delegated-tf')
+    - $${workspace}: The workspace/environment name from YAML filename (e.g., 'dev', 'prod')
+    - $${module_path}: The root module path for S3 backend workspace isolation (e.g., 'aws-iam/delegated-tf')
+    Examples:
+    - "$${workspace}-$${module_path}" (default for MultiInstance)
+    - "$${module_name}" (default for SingleInstance)
+  EOT
+  default     = null
+
+  validation {
+    condition     = var.stack_name_template == null || can(regex("\\$\\{(module_name|workspace|module_path)\\}", var.stack_name_template))
+    error_message = "stack_name_template must contain at least one of: $${module_name}, $${workspace}, or $${module_path}"
+  }
+}
+
 variable "spaces" {
   description = "A map of Spacelift Spaces to create"
   type = map(object({


### PR DESCRIPTION
## what

- allow stack id's to have formatted names

## why

- for multi-instance stacks, it can help to organize them by keeping the workspace as a prefix rather than suffix
- some folks prefer a different pattern (or maybe even separator) for stack id slugs
