### PR TITLE
chore: remove dead administrative references post role-attachment migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ automation_settings:
 
 ### How do I give a stack Spacelift management permissions? (Role Attachments)
 
-Stacks that manage other Spacelift resources (e.g. the spacelift-automation stack itself) need elevated permissions. The way to grant this is via a **role attachment**, which replaces the deprecated `administrative` flag.
+Stacks that manage other Spacelift resources (e.g. the spacelift-automation stack itself) need elevated permissions. The way to grant this is via a **role attachment**, which replaces the deprecated `administrative` flag. At minimum, the spacelift-automation stack itself needs `space-admin` so it can manage other stacks and their role attachments.
 
 #### Using a built-in role
 
@@ -245,7 +245,7 @@ stack_settings:
   role_attachment_role_slug: space-admin
 ```
 
-Or apply it to every stack managed by a module instance via `var.role_attachment`:
+You can also give every stack managed by a module instance a role via `var.role_attachment`. `space-admin` is only needed when a stack itself manages Spacelift resources — otherwise pick a less-privileged role (or none):
 
 ```hcl
 module "spacelift_automation" {

--- a/main.tf
+++ b/main.tf
@@ -15,10 +15,9 @@
 # * Space IDs: in the majority of cases all the workspaces in a root module belong to the same Spacelift space, so
 # we allow setting a "global" space_id for all stacks on a root module level.
 # * Autodeploy: if all the stacks in a root module should be autodeployed.
-# * Administrative: if all the stacks in a root module are administrative, e.g stacks that manage Spacelift resources.
 #
 # 3. Labels (see ## Labels)
-# Generates labels for the stacks based on administrative, dependency, and folder information.
+# Generates labels for the stacks based on dependency and folder information.
 #
 # Syntax note:
 # The local expression started with an underscore `_` is used to store intermediate values
@@ -403,9 +402,8 @@ locals {
     stack => config if try(config.destructor_enabled, var.destructor_enabled)
   }
 
-  # Filter stacks that need a Spacelift role attached (replaces the deprecated administrative flag).
-  # A role attachment is created when a per-stack `role_attachment_role_slug` is set in the stack's
-  # YAML config, OR when the module-level `var.role_attachment` is configured (applies to all stacks).
+  # Role attachments are created for any stack with a per-stack `role_attachment_role_slug`
+  # or when module-level `var.role_attachment` is set (applies to all stacks).
   role_attachment_stacks = {
     for stack, config in local.stack_configs :
     stack => config if try(config.role_attachment_role_slug, null) != null || var.role_attachment != null
@@ -617,6 +615,11 @@ resource "spacelift_space" "default" {
 # The role slug must be provided explicitly via per-stack `role_attachment_role_slug` in YAML
 # or via the module-level `var.role_attachment.role_slug`. Use `role_attachment_space_id`
 # (per-stack or module-level) to attach in a space other than the stack's own space.
+#
+# Bootstrapping the automation stack itself: the spacelift-automation stack manages other Spacelift
+# resources (including role attachments for the stacks it creates), so its own stack config must set
+# `stack_settings.role_attachment_role_slug: space-admin` (or an equivalent custom role with
+# SPACE_ADMIN actions). Without it, runs fail with `could not create stack role binding: unauthorized`.
 resource "spacelift_role_attachment" "default" {
   for_each = local.role_attachment_stacks
 

--- a/stack-config.schema.json
+++ b/stack-config.schema.json
@@ -35,19 +35,6 @@
       "description": "Core stack settings, these overwrite the defaults set in the spacelift-automation module",
       "additionalProperties": false,
       "properties": {
-        "administrative": {
-          "type": "boolean",
-          "description": "DEPRECATED: Use role_attachment_role_slug instead. This property is no longer supported and will be ignored.",
-          "deprecated": true
-        },
-        "role_attachment_role_slug": {
-          "type": "string",
-          "description": "Role to attach to this stack. Setting this creates a spacelift_role_attachment resource for the stack. Accepts: built-in slugs ('space-admin', 'space-writer', 'space-reader'), slugs of pre-existing custom roles, or a key from var.managed_roles to reference a role created by this module. Overrides the module-level var.role_attachment.role_slug for this stack."
-        },
-        "role_attachment_space_id": {
-          "type": "string",
-          "description": "ID of the space in which the role attachment is created. Defaults to the stack's own space. Set to a different space ID for cross-space access."
-        },
         "role_attachment_role_slug": {
           "type": "string",
           "description": "Role to attach to this stack. Setting this creates a spacelift_role_attachment resource for the stack. Accepts: built-in slugs ('space-admin', 'space-writer', 'space-reader'), slugs of pre-existing custom roles, or a key from var.managed_roles to reference a role created by this module. Overrides the module-level var.role_attachment.role_slug for this stack."

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -813,7 +813,7 @@ run "test_workspace_when_default_tf_workspace_enabled" {
 }
 
 # Test that a role attachment is created for a stack with role_attachment_role_slug set in YAML
-run "test_role_attachment_is_created_for_administrative_stack" {
+run "test_role_attachment_is_created_when_role_slug_set" {
   command = plan
 
   assert {
@@ -823,7 +823,7 @@ run "test_role_attachment_is_created_for_administrative_stack" {
 }
 
 # Test that no role attachment is created for a stack without role_attachment_role_slug set
-run "test_role_attachment_is_not_created_for_non_administrative_stack" {
+run "test_role_attachment_is_not_created_when_role_slug_absent" {
   command = plan
 
   assert {

--- a/tests/single-instance.tftest.hcl
+++ b/tests/single-instance.tftest.hcl
@@ -108,7 +108,7 @@ run "test_single_instance_stack_configs_custom_project_root_is_used_when_specifi
 }
 
 # Test that no role attachment is created for a single-instance stack without role_attachment_role_slug
-run "test_single_instance_role_attachment_is_not_created_for_non_administrative_stack" {
+run "test_single_instance_role_attachment_is_not_created_when_role_slug_absent" {
   command = plan
 
   assert {


### PR DESCRIPTION
Closes #120

## Summary

Cleanup pass after the v2.0.0 role-attachment migration. The `administrative` flag was replaced by `spacelift_role_attachment`, but leftover references remained scattered across the module. Also adds a brief note on the automation stack's own permission requirement, which wasn't documented.

## Changes

- **`main.tf`**: drop dead `Administrative:` bullet from header comments; add bootstrap guidance next to the `spacelift_role_attachment` resource explaining why the automation stack itself needs `space-admin`.
- **`stack-config.schema.json`**: remove deprecated `administrative` property (was marked ignored) and duplicate `role_attachment_role_slug` / `role_attachment_space_id` entries.
- **`README.md`**: note that the automation stack itself needs `space-admin`; reword the `var.role_attachment` example to clarify `space-admin` is only required for stacks that manage Spacelift resources — otherwise a less-privileged role (or none) is fine.
- **`tests/main.tftest.hcl`, `tests/single-instance.tftest.hcl`**: rename `*_for_administrative_stack` / `*_for_non_administrative_stack` tests to reflect the current `role_attachment_role_slug` semantics.

## Test plan

- [x] `tofu test` — 64 passed, 0 failed
- [x] `tofu validate` — config valid
- [x] `tofu fmt` — no diff