### PR TITLE
chore: Add GitHub Actions workflow for zizmor (INT-1582)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,15 +6,15 @@ concurrency:
 
 on: pull_request
 
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  pull-requests: read
-
+permissions: {}
+  
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     steps:
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,6 +27,8 @@ jobs:
 
   conventional-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ name: Lint
 on: pull_request
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,15 +1,16 @@
 name: Lint
 
-concurrency:
-  group: lint-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions: {}
   
 jobs:
   lint:
+    name: 📝 lint
     runs-on: ubuntu-latest
     permissions:
       actions: read # needed by trunk-action to read workflow run context
@@ -28,6 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   conventional-title:
+    name: 📝 conventional title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read # needed by action-semantic-pull-request to inspect pull request context

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      checks: write
-      contents: read
+      actions: read # needed by trunk-action to read workflow run context
+      checks: write # needed by trunk-action to write check results
+      contents: read # needed by trunk-action to read repository contents
     steps:
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,7 +30,7 @@ jobs:
   conventional-title:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: read # needed by action-semantic-pull-request to inspect pull request context
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions: {}
-  
+
 jobs:
   lint:
     name: 📝 lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ concurrency:
   group: lint-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: pull_request_target
+on: pull_request
 
 permissions:
   actions: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: pull_request
+# We ignore the dangerous-triggers warning because forked PRs
+# require repo secrets to run some of the defined checks,
+# and we protect against malicious actors by requiring approval
+# for all external contributors before workflows will run.
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         env:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,15 +5,19 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: write # needed by release-please-action to write repository contents
+      pull-requests: write # needed by release-please-action to write pull requests
+      issues: write # needed by release-please-action to write issues
     steps:
       - name: Create Token for MasterpointBot App
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   release-please:
+    name: 📦 release please
     runs-on: ubuntu-latest
     permissions:
       contents: write # needed by release-please-action to write repository contents

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Create Token for MasterpointBot App
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # We ignore the dangerous-triggers warning because forked PRs
+  # require repo secrets to run some of the defined checks,
+  # and we protect against malicious actors by requiring approval
+  # for all external contributors before workflows will run.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,17 +6,18 @@ on:
       - main
   pull_request:
 
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  id-token: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   tf-test:
     name: 🧪 ${{ matrix.tf }} test
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      id-token: write
+      pull-requests: read
     env:
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -13,11 +17,11 @@ jobs:
     name: 🧪 ${{ matrix.tf }} test
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      checks: write
-      contents: read
-      id-token: write
-      pull-requests: read
+      actions: read # needed by github-action-tf-test to read workflow run context
+      checks: write # needed by github-action-tf-test to write check results
+      contents: read # needed by github-action-tf-test to read repository contents
+      id-token: write # needed by github-action-tf-test to write id token
+      pull-requests: read # needed by github-action-tf-test to read pull request context
     env:
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
 
 permissions:
   actions: read

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -22,12 +22,12 @@ jobs:
       pull-requests: write # needed by github-action-trunk-upgrade to write pull requests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.22
         with:
           persist-credentials: false
 
       - name: Run Trunk Upgrade
-        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0
+        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999
         with:
           app-id: ${{ secrets.MP_BOT_APP_ID }}
           app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -6,6 +6,10 @@ on:
     - cron: 0 8 1 * *
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -13,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # For trunk to create PRs
-      contents: write
-      pull-requests: write
+      contents: write # needed by github-action-trunk-upgrade to write repository contents
+      pull-requests: write # needed by github-action-trunk-upgrade to write pull requests
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -6,7 +6,7 @@ on:
     - cron: 0 8 1 * *
   workflow_dispatch: {}
 
-permissions: read-all
+permissions: {}
 
 jobs:
   trunk-upgrade:

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trunk Upgrade
         uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -22,12 +22,12 @@ jobs:
       pull-requests: write # needed by github-action-trunk-upgrade to write pull requests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.22
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run Trunk Upgrade
-        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999
+        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0
         with:
           app-id: ${{ secrets.MP_BOT_APP_ID }}
           app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -14,6 +14,7 @@ permissions: {}
 
 jobs:
   trunk-upgrade:
+    name: 📦 trunk upgrade
     runs-on: ubuntu-latest
     permissions:
       # For trunk to create PRs

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
+          # Set to false, so zizmor will not upload results to Github Advanced Security
+          # and will instead print them to the Action's run log.
           advanced-security: false
+          # Set to pedantic so that zizmor will run it's stale-action-refs audit rule
           persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,4 +21,4 @@ jobs:
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           advanced-security: false
-          persona: pedantic
+          persona: regular

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,9 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
   pull_request:
-    branches: ["**"]
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,4 +21,4 @@ jobs:
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           advanced-security: false
-          persona: regular
+          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,6 +14,7 @@ permissions: {}
 
 jobs:
   zizmor:
+    name: 🌈 zizmor
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## What

- Adds a new zizmor.yml workflow that runs [zizmor](https://docs.zizmor.sh/) — a static analysis tool for GitHub Actions security — on every push to `main` and every pull request, using pedantic [persona](https://docs.zizmor.sh/usage/#using-personas).
- Fixes all findings zizmor raised across the four existing workflow files (`lint.yaml`, `test.yaml`, `release-please.yaml`, `trunk-upgrade.yaml`).
- This is the first repo we are using this on, so **all feedback is appreciated, as decisions here will set the standard for our other repos.** 

---

## Why

We use the pedantic persona in order to utilize the [stale-action-ref](https://docs.zizmor.sh/audits/#stale-action-refs) audit rule.

Zizmor audited the existing workflows and found various violations. Each is explained below with one concrete example from this branch.

#### `excessive-permissions` — broad permissions granted at the workflow level

Permissions defined at the top-level `permissions:` block apply to every job in the workflow. Granting `contents: write` or `id-token: write` at that scope means even jobs that don't need those permissions inherit them, widening the blast radius of a compromised step.

**Before (`test.yaml`):**
```yaml
permissions:
  actions: read
  checks: write
  contents: read
  id-token: write
  pull-requests: read
```
**After:** workflow level is locked down, permissions live only on the job that needs them:
```yaml
permissions: {}   # workflow level — no default grants

jobs:
  tf-test:
    permissions:
      id-token: write
      # ...
```

---

#### `undocumented-permissions` — permissions lack explanatory comments (pedantic)

With `persona: pedantic`, zizmor requires every permission entry to have a comment explaining *why* it's needed. Without comments, reviewers can't tell whether a permission is intentional or cargo-culted.

**Before (`trunk-upgrade.yaml`):**
```yaml
permissions:
  contents: write
  pull-requests: write
```
**After:**
```yaml
permissions:
  contents: write      # needed by github-action-trunk-upgrade to write repository contents
  pull-requests: write # needed by github-action-trunk-upgrade to write pull requests
```

---

#### `artipacked` — `actions/checkout` persisting credentials onto disk

By default, `actions/checkout` writes the GitHub token into `.git/config` so subsequent `git` commands are pre-authenticated. If any later step uploads the workspace as an artifact, that token ships with it.

**Before (`lint.yaml`):**
```yaml
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
```
**After:**
```yaml
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
  with:
    persist-credentials: false
```

---

#### `anonymous-definition` — job definitions without a name

Without an explicit `name:`, jobs appear in the GitHub Actions UI using only their YAML key (e.g. `conventional-title`). This makes it harder to identify jobs at a glance in the checks panel and status emails, and zizmor treats unnamed definitions as an audit gap.

**Before (`lint.yaml`):**
```yaml
jobs:
  conventional-title:
    runs-on: ubuntu-latest
```
**After:**
```yaml
jobs:
  conventional-title:
    name: 📝 conventional title
    runs-on: ubuntu-latest
```

---

#### `concurrency-limits` — missing workflow-level concurrency controls

Without a `concurrency:` block, multiple runs of the same workflow can execute simultaneously — for example, two pushes in quick succession both triggering `release-please`. This wastes runner resources and can cause race conditions on shared state like release PRs or tags.

**Before (`release-please.yaml`):**
```yaml
on:
  push:
    branches:
      - main

permissions: {}
```
**After:**
```yaml
on:
  push:
    branches:
      - main

concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```
`head_ref` is preferred because it's stable per PR branch (enabling cancellation of redundant runs), with ref as the fallback for non-PR events where head_ref is empty.

## references

- [INT-1582](https://www.notion.so/masterpoint/Roll-out-Zizmor-across-all-Masterpoint-OSS-repos-08a6992b18de4b9581bec3eb579715b1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security analysis tool to validate GitHub Actions workflow configurations
  
* **Chores**
  * Enhanced pipeline security with restrictive default permissions and job-level access controls
  * Implemented concurrency management to prevent simultaneous redundant workflow runs
  * Optimized pull request workflow triggers and credential handling for improved security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->