### PR TITLE
fix: rm lint emoji until I roll out new centralized workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   lint:
-    name: 📝 lint
+    name: lint
     runs-on: ubuntu-latest
     permissions:
       actions: read # needed by trunk-action to read workflow run context
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   conventional-title:
-    name: 📝 conventional title
+    name: conventional title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read # needed by action-semantic-pull-request to inspect pull request context


### PR DESCRIPTION
## what

- remove lint emoji that is conflicting with our branch protection rule

## why

- making this small/quick PR untilI roll out centralized workflows as a separate task 

## references

- [INT-1582](08a6992b18de4b9581bec3eb579715b1)
