### PR TITLE
fix: zizmor cmd name fix (INT-1582)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ name: Lint
 # require repo secrets to run some of the defined checks,
 # and we protect against malicious actors by requiring approval
 # for all external contributors before workflows will run.
-on: pull_request_target # zizmor: ignore[dangerous-triggers]
+on: pull_request_target
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ name: Lint
 # require repo secrets to run some of the defined checks,
 # and we protect against malicious actors by requiring approval
 # for all external contributors before workflows will run.
-on: pull_request_target
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -42,9 +42,8 @@ lint:
           optional: true
       commands:
         # Set to pedantic so that zizmor will run its stale-action-refs audit rule
-        - name: zizmor-static-analysis
+        - name: lint
           run: zizmor --format=sarif --persona=pedantic ${target}
-          success_codes: [0]
   ignore:
     - linters: [tofu]
       paths:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -44,6 +44,7 @@ lint:
         # Set to pedantic so that zizmor will run its stale-action-refs audit rule
         - name: zizmor-static-analysis
           run: zizmor --format=sarif --persona=pedantic ${target}
+          success_codes: [0]
   ignore:
     - linters: [tofu]
       paths:


### PR DESCRIPTION
## what

- Change zizmor command name to `lint`

## why

- By using a custom name of `zizmor-static-analysis`, we lose all the defaults defined [here](https://github.com/trunk-io/plugins/blob/main/linters/zizmor/plugin.yaml#L16). This requires specifying all the options such as `output`, `success_codes`, etc. 

## references

- [INT-1582](https://www.notion.so/masterpoint/Roll-out-Zizmor-across-all-Masterpoint-OSS-repos-08a6992b18de4b9581bec3eb579715b1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tool configuration settings for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->